### PR TITLE
Add BudSimHardwares helper

### DIFF
--- a/src/BudSimHardwares.py
+++ b/src/BudSimHardwares.py
@@ -1,0 +1,44 @@
+from typing import Dict, Any, List, Optional
+from pydantic import BaseModel
+from Systems.system_configs import system_configs
+
+class Hardware(BaseModel):
+    """Pydantic model mirroring a single hardware configuration."""
+    Flops: int
+    Memory_size: int
+    Memory_BW: int
+    ICN: int
+    ICN_LL: Optional[float] = None
+    real_values: bool = True
+
+class BudHardwares:
+    """Utility class to manage Bud simulator hardware presets."""
+
+    def __init__(self, hardwares: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
+        if hardwares is None:
+            hardwares = system_configs
+        self._hardwares: Dict[str, Hardware] = {
+            name: Hardware(**cfg) for name, cfg in hardwares.items()
+        }
+
+    def list_hardwares(self) -> List[str]:
+        """Return a list of supported hardware names."""
+        return list(self._hardwares.keys())
+
+    def get_hardware(self, name: str) -> Hardware:
+        """Retrieve a hardware configuration by name."""
+        return self._hardwares[name]
+
+    def add_hardware(self, name: str, config: Dict[str, Any]) -> None:
+        """Add a new hardware configuration."""
+        self._hardwares[name] = Hardware(**config)
+
+    def update_hardware(self, name: str, config: Dict[str, Any]) -> None:
+        """Update an existing hardware configuration."""
+        if name not in self._hardwares:
+            raise KeyError(f"Hardware {name} not found")
+        self._hardwares[name] = self._hardwares[name].copy(update=config)
+
+    def to_dict(self) -> Dict[str, Dict[str, Any]]:
+        """Return all hardware configurations as a dictionary."""
+        return {name: hw.dict() for name, hw in self._hardwares.items()}

--- a/tests/test_budsim_hardware.py
+++ b/tests/test_budsim_hardware.py
@@ -1,0 +1,25 @@
+import pytest
+from src.BudSimHardwares import BudHardwares, Hardware
+from Systems.system_configs import system_configs
+
+
+def test_list_contains_default_hardware():
+    manager = BudHardwares()
+    for name in system_configs.keys():
+        assert name in manager.list_hardwares()
+
+
+def test_add_and_get_hardware():
+    manager = BudHardwares()
+    new_cfg = {"Flops": 100, "Memory_size": 64, "Memory_BW": 2000, "ICN": 100}
+    manager.add_hardware("TEST_HW", new_cfg)
+    hw = manager.get_hardware("TEST_HW")
+    assert isinstance(hw, Hardware)
+    assert hw.Flops == 100
+
+
+def test_update_hardware():
+    manager = BudHardwares()
+    name = manager.list_hardwares()[0]
+    manager.update_hardware(name, {"Flops": 999})
+    assert manager.get_hardware(name).Flops == 999


### PR DESCRIPTION
## Summary
- add `BudSimHardwares` module under new `src` folder
- provide `Hardware` pydantic model to match hardware configs
- provide `BudHardwares` manager class for listing, adding and updating hardware profiles
- test new hardware manager

## Testing
- `PYTHONPATH=. pytest -q tests/test_budsim_hardware.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*